### PR TITLE
fix: ts-node@10.9.1" has unmet peer dependency "@types/node@*"

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -28,6 +28,7 @@
     "@types/chai": "^4.3.3",
     "@types/eslint": "^8.4.9",
     "@types/mocha": "^10.0.0",
+    "@types/node": "^20.10.0",
     "@types/request": "^2.48.8",
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.42.0",

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -1040,6 +1040,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@^20.10.0":
+  version "20.10.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.0.tgz#16ddf9c0a72b832ec4fcce35b8249cf149214617"
+  integrity sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -4213,6 +4220,11 @@ underscore@~1.13.2:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR addresses the warning message related to the ts-node package in our project. The warning indicated an unmet peer dependency on @types/node, which ts-node expects to be installed in the project.

Changes made:

Added @types/node as a devDependency in our package.json file.
This addition ensures that ts-node can find and use @types/node as expected, eliminating the warning message. This change does not affect the runtime behavior of our application, as @types/node is a type definition package used only in development.

By addressing this warning, we maintain a clean and clear console output, making it easier to spot and address other potential issues in the future.

Before fixes: 
![image](https://github.com/oddbit/firebase-alerts/assets/18025983/ba1b309f-904e-4498-9a08-a62bafa41187)


After fixes:
![image](https://github.com/oddbit/firebase-alerts/assets/18025983/2ace07b1-b451-4403-a752-0f4ddaa047d9)
